### PR TITLE
[FIX] TypeError: top.jsUnitTestSuite is not a constructor

### DIFF
--- a/lib/client/discovery.js
+++ b/lib/client/discovery.js
@@ -161,9 +161,12 @@ const assign = require("lodash.assign");
 		}
 
 		const origTestSuite = window.jsUnitTestSuite;
+		const origTopTestSuite = top.jsUnitTestSuite;
 		window.jsUnitTestSuite = TestSuite;
+		top.jsUnitTestSuite = TestSuite;
 		return checkTestPage({fullpage: sEntryPage}).finally(function() {
 			window.jsUnitTestSuite = origTestSuite;
+			top.jsUnitTestSuite = origTopTestSuite;
 		});
 	}
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "itest:app-no-htmlrunner": "karma start test/integration/application-no-htmlrunner/karma.conf.js",
     "itest:library-proxy": "karma start test/integration/library-proxy/karma.conf.js",
     "itest:library-ui5-tooling": "karma start test/integration/library-ui5-tooling/karma.conf.js",
+    "itest:library-ui5-tooling-multiple-testsuites": "karma start test/integration/library-ui5-tooling-multiple-testsuites/karma.conf.js",
     "itest:library-custompath": "karma start test/integration/library-custompath/karma.conf.js",
     "postinstall": "webpack --silent",
     "preversion": "npm test",

--- a/test/integration/library-ui5-tooling-multiple-testsuites/karma.conf.js
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/karma.conf.js
@@ -1,0 +1,20 @@
+module.exports = function(config) {
+	"use strict";
+
+	require("../karma-base.conf")(config);
+	config.set({
+
+		frameworks: ["ui5"],
+
+		ui5: {
+			testpage: "test/sap/test/lib/qunit/testsuite.qunit.html"
+		},
+
+		plugins: [
+			require("../../../lib"),
+			require("karma-chrome-launcher")
+		],
+
+
+	});
+};

--- a/test/integration/library-ui5-tooling-multiple-testsuites/package.json
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "library-ui5-tooling-multiple-testsuites",
+	"version": "1.0.0",
+	"dependencies": {
+		"@openui5/sap.ui.core": "*"
+	}
+}

--- a/test/integration/library-ui5-tooling-multiple-testsuites/src/sap/test/lib/library.js
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/src/sap/test/lib/library.js
@@ -1,0 +1,13 @@
+sap.ui.define(["sap/ui/core/library"], function() {
+	"use strict";
+
+	sap.ui.getCore().initLibrary({
+		name: "sap.test.lib",
+		dependencies: ["sap.ui.core"],
+		controls: [],
+		elements: [],
+		noLibraryCSS: true
+	});
+
+	return sap.test.lib;
+});

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/.dotfile
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/.dotfile
@@ -1,0 +1,1 @@
+dotfile

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/foo/test.qunit.html
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/foo/test.qunit.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>QUnit Test</title>
+
+	<script id="sap-ui-bootstrap" src="../../../../../../resources/sap-ui-core.js" data-sap-ui-libs="sap.test.lib"></script>
+	<link rel="stylesheet" href="../../../../../../resources/sap/ui/thirdparty/qunit-2.css">
+	<script src="../../../../../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+	<script src="../test.qunit.js"></script> <!-- just run the same test -->
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/test.qunit.html
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/test.qunit.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>QUnit Test</title>
+
+	<script id="sap-ui-bootstrap" src="../../../../../resources/sap-ui-core.js" data-sap-ui-libs="sap.test.lib"></script>
+	<link rel="stylesheet" href="../../../../../resources/sap/ui/thirdparty/qunit-2.css">
+	<script src="../../../../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+	<script src="./test.qunit.js"></script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/test.qunit.js
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/test.qunit.js
@@ -1,0 +1,18 @@
+/* global QUnit */
+
+QUnit.config.autostart = false;
+
+sap.ui.getCore().attachInit(function() {
+	"use strict";
+
+	QUnit.test("Karma", function(assert) {
+		assert.ok(parent.__karma__.files["/base/src/sap/test/lib/.library"], "Karma src files should contain dotfiles");
+		assert.ok(parent.__karma__.files["/base/test/.dotfile"], "Karma test files should contain dotfiles");
+	});
+
+	QUnit.test("sap.test.lib", function(assert) {
+		assert.ok(sap.ui.getCore().getLoadedLibraries()["sap.test.lib"], "Library has been loaded");
+	});
+
+	QUnit.start();
+});

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.foo.qunit.html
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.foo.qunit.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Testsuite</title>
+	<script src="../../../../../resources/sap/ui/qunit/qunit-redirect.js"></script>
+	<script src="testsuite.foo.qunit.js" data-sap-ui-testsuite></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.foo.qunit.js
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.foo.qunit.js
@@ -1,0 +1,13 @@
+/* global window, top, location */
+
+// eslint-disable-next-line sap-no-global-define
+window.suite = function() {
+	"use strict";
+
+	// eslint-disable-next-line
+	var oSuite = new top.jsUnitTestSuite(),
+		sContextPath = location.pathname.substring(0, location.pathname.lastIndexOf("/") + 1);
+	oSuite.addTestPage(sContextPath + "foo/test.qunit.html");
+
+	return oSuite;
+};

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.qunit.html
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.qunit.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Testsuite</title>
+	<script src="../../../../../resources/sap/ui/qunit/qunit-redirect.js"></script>
+	<script src="testsuite.qunit.js" data-sap-ui-testsuite></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.qunit.js
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/test/sap/test/lib/qunit/testsuite.qunit.js
@@ -1,0 +1,14 @@
+/* global window, top, location */
+
+// eslint-disable-next-line sap-no-global-define
+window.suite = function() {
+	"use strict";
+
+	// eslint-disable-next-line
+	var oSuite = new top.jsUnitTestSuite(),
+		sContextPath = location.pathname.substring(0, location.pathname.lastIndexOf("/") + 1);
+	oSuite.addTestPage(sContextPath + "test.qunit.html");
+	oSuite.addTestPage(sContextPath + "testsuite.foo.qunit.html");
+
+	return oSuite;
+};

--- a/test/integration/library-ui5-tooling-multiple-testsuites/ui5.yaml
+++ b/test/integration/library-ui5-tooling-multiple-testsuites/ui5.yaml
@@ -1,0 +1,5 @@
+---
+specVersion: "0.1"
+type: library
+metadata:
+  name: sap.x


### PR DESCRIPTION
Testsuites might be using top.jsUnitTestSuite to get the testsuite
class. Therefore both it should be available in "parent" and "top".