### PR TITLE
[INTERNAL] Use ui5-server middlewareRepository

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -1,5 +1,5 @@
 const normalizer = require("@ui5/project").normalizer;
-const ui5middleware = require("@ui5/server").middleware;
+const middlewareRepository = require("@ui5/server").middlewareRepository;
 const ui5Fs = require("@ui5/fs");
 const resourceFactory = ui5Fs.resourceFactory;
 const ReaderCollectionPrioritized = ui5Fs.ReaderCollectionPrioritized;
@@ -406,20 +406,20 @@ class Framework {
 			name: tree.metadata.name
 		});
 
-		const combo = new ReaderCollectionPrioritized({
+		const all = new ReaderCollectionPrioritized({
 			name: "server - prioritize workspace over dependencies",
 			readers: [workspace, projectResourceCollections.dependencies]
 		});
 
-		const resourceCollections = {
-			source: projectResourceCollections.source,
+		const resources = {
+			rootProject: projectResourceCollections.source,
 			dependencies: projectResourceCollections.dependencies,
-			combo
+			all
 		};
 
 		return {
-			serveResources: ui5middleware.serveResources({resourceCollections}),
-			serveThemes: ui5middleware.serveThemes({resourceCollections})
+			serveResources: middlewareRepository.getMiddleware("serveResources")({resources}),
+			serveThemes: middlewareRepository.getMiddleware("serveThemes")({resources})
 		};
 	}
 

--- a/test/__mocks__/@ui5/server.js
+++ b/test/__mocks__/@ui5/server.js
@@ -1,14 +1,13 @@
 const server = jest.genMockFromModule("@ui5/server");
-server.middleware = {
-	serveResources: () => {
-		return function(req, res, next) {
-			next();
-		};
-	},
-	serveThemes: () => {
-		return function(req, res, next) {
-			next();
-		};
+server.middlewareRepository = {
+	getMiddleware: (name) => {
+		if (name === "serveResources" || name === "serveThemes") {
+			return function() {
+				return function(req, res, next) {
+					next();
+				};
+			};
+		}
 	}
 };
 module.exports = server;


### PR DESCRIPTION
Removes usage of private API.
The middlewareRepository has been introduced with ui5-server v1.2.0:
https://github.com/SAP/ui5-server/compare/v1.1.3...v1.2.0