### PR TITLE
Allow usage with non-blacklisted karma plugins

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,8 +1,8 @@
 module.exports = {
 	ErrorMessage: {
-		multipleFrameworks: (frameworks) => {
+		blacklistedFrameworks: (frameworks) => {
 			let errorMessage = "error 1:\nThe \"karma-ui5\" plugin is not compatible " +
-				"with other framework plugins when running in \"html\" mode.";
+				"with certain framework plugins when running in \"html\" mode.";
 			if (frameworks.includes("qunit")) {
 				errorMessage += "\nQUnit is supported out of the box.";
 			}
@@ -10,14 +10,7 @@ module.exports = {
 				errorMessage += "\nSinon should be loaded from the test.";
 			}
 			errorMessage += `
-Please make sure to define "ui5" as the only framework in your karma config:
-
-module.exports = function(config) {
-	config.set({
-		frameworks: ["ui5"]
-	});
-};
-			`;
+Please make sure not to define "ui5" along with any of the above mentioned plugins your karma config.`;
 			return errorMessage;
 		},
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -134,8 +134,10 @@ class Framework {
 			throw new Error(ErrorMessage.failure());
 		}
 
-		if (this.config.frameworks && this.config.frameworks.length > 1 && this.config.ui5.mode === "html") {
-			this.logger.log("error", ErrorMessage.multipleFrameworks(this.config.frameworks) );
+		const blacklistedFrameworks = ["qunit", "sinon"];
+		const hasBlacklistedFrameworks = (frameworks) => frameworks.some((fwk) => blacklistedFrameworks.includes(fwk));
+		if (this.config.ui5.mode === "html" && hasBlacklistedFrameworks(this.config.frameworks || [])) {
+			this.logger.log("error", ErrorMessage.blacklistedFrameworks(this.config.frameworks) );
 			throw new Error(ErrorMessage.failure());
 		}
 

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -765,14 +765,6 @@ describe("Error logging", () => {
 		expect(framework.logger.message).toBe(ErrorMessage.migrateConfig());
 	});
 
-	it("Should throw if multiple frameworks have been defined", () => {
-		const config = {
-			frameworks: ["foo", "ui5"]
-		};
-		expect(() => framework.init({config, logger})).toThrow();
-		expect(framework.logger.message).toBe(ErrorMessage.multipleFrameworks(["foo", "ui5"]));
-	});
-
 	it("Should throw if invalid mode is defined", () => {
 		const config = {
 			ui5: {
@@ -845,20 +837,28 @@ describe("Error logging", () => {
 		}));
 	});
 
-	it("Should throw if multiple frameworks have been defined (qunit)", () => {
+	it("Should now throw if a non-backlisted framework has been defined", () => {
+		const config = {
+			frameworks: ["foo", "ui5"]
+		};
+		expect(() => framework.init({config, logger})).toThrow(); // some unrelated exception
+		expect(framework.logger.message).not.toBe(ErrorMessage.blacklistedFrameworks(["foo", "ui5"]));
+	});
+
+	it("Should throw if a blacklisted framework has been defined (qunit)", () => {
 		const config = {
 			frameworks: ["qunit", "ui5"]
 		};
 		expect(() => framework.init({config, logger})).toThrow();
-		expect(framework.logger.message).toBe(ErrorMessage.multipleFrameworks(["qunit", "ui5"]));
+		expect(framework.logger.message).toBe(ErrorMessage.blacklistedFrameworks(["qunit", "ui5"]));
 	});
 
-	it("Should throw if multiple frameworks have been defined (qunit + sinon)", () => {
+	it("Should throw if a blacklisted framework has been defined (qunit + sinon)", () => {
 		const config = {
 			frameworks: ["qunit", "sinon", "ui5"]
 		};
 		expect(() => framework.init({config, logger})).toThrow();
-		expect(framework.logger.message).toBe(ErrorMessage.multipleFrameworks(["qunit", "sinon", "ui5"]));
+		expect(framework.logger.message).toBe(ErrorMessage.blacklistedFrameworks(["qunit", "sinon", "ui5"]));
 	});
 
 	it("Should throw if files have been defined in config", () => {

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -837,7 +837,7 @@ describe("Error logging", () => {
 		}));
 	});
 
-	it("Should now throw if a non-backlisted framework has been defined", () => {
+	it("Should not throw if a non-backlisted framework has been defined", () => {
 		const config = {
 			frameworks: ["foo", "ui5"]
 		};


### PR DESCRIPTION
This PR addresses #162. 

Instead of preventing the use of `karma-ui5` with all other Karma plugins, this PR introduces a blacklist of certain plugins that are not compatible with `karma-ui5`. These plugins currently include `qunit` and `sinon`.

/cc @CCFenner 