### PR TITLE
[BREAKING] Require Node.js >= 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,3 @@ matrix:
     - os: linux
       node_js:
         - "10"
-    - os: linux
-      node_js:
-        - "8"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "karma-plugin"
   ],
   "engines": {
-    "node": ">= 8.5",
+    "node": ">= 10.0",
     "npm": ">= 5"
   },
   "repository": {


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js releases has been dropped.
Only Node.js v10 or higher is supported.