### PR TITLE
[FIX] Improve performance when serving UI5 resources via URL

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -2,6 +2,7 @@ const normalizer = require("@ui5/project").normalizer;
 const ui5Fs = require("@ui5/fs");
 const resourceFactory = ui5Fs.resourceFactory;
 const ReaderCollectionPrioritized = ui5Fs.ReaderCollectionPrioritized;
+const http = require("http");
 const httpProxy = require("http-proxy");
 const fs = require("fs");
 const path = require("path");
@@ -440,9 +441,11 @@ class Framework {
 	}
 
 	setupProxy({url}) {
+		const agent = new http.Agent({keepAlive: true});
 		const proxy = httpProxy.createProxyServer({
 			target: url,
-			changeOrigin: true
+			changeOrigin: true,
+			agent
 		});
 
 		return {

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -147,9 +147,13 @@ describe("Proxy for UI5 ", () => {
 
 		const createProxyServer = require("http-proxy").createProxyServer;
 
-		expect(createProxyServer).toBeCalledWith({
+		const lastCall = createProxyServer.mock.calls[createProxyServer.mock.calls.length - 1];
+		expect(lastCall[0]).toMatchObject({
 			target: "http://localhost",
-			changeOrigin: true
+			changeOrigin: true,
+			agent: expect.objectContaining({
+				keepAlive: true
+			})
 		});
 
 		// const proxy = require("http-proxy").createProxyServer.mock.results[0].value;


### PR DESCRIPTION
Using an agent with "keepAlive" improves performance when proxing
requests, especially on Windows.