### PR TITLE
Readme: Move mode section one level up, add minimum running example for script mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
 - [Quickstart](#quickstart)
 	- [Installation](#installation)
 	- [Configuration](#configuration)
+		- [Script Mode](#script-mode)
 	- [Execution](#execution)
 - [Karma Configuration Requirements](#karma-configuration-requirements)
-- [mode](#mode)
-	- [html](#html)
-	- [script](#script)
-      - [Minimum running configuration example](#minimum-running-configuration-example)
 - [Options](#options)
 	- [url](#url)
 	- [type](#type)
 	- [paths](#paths)
 	- [configPath](#configpath)
+	- [mode](#mode)
+		- [html](#html)
+		- [script](#script)
 	- [testpage](#testpage)
 	- [urlParameters](#urlparameters)
 	- [config](#config)
@@ -87,6 +87,78 @@ module.exports = function(config) {
 };
 ```
 
+#### Script Mode
+
+*(Optional, next step: [Execution](#execution))*
+
+The configuration above implies to use the [`html` mode](#html), which is recommended.
+It runs your existing test pages and does not require additional Karma plugins or configuration.
+
+However the [`script` mode](#script) is more flexible and better allows integration with other karma plugins / frameworks.
+
+The following steps describe a minimal configuration for the `script` mode.
+
+With the `script` mode you need to also include a testing framework and its Karma adapter, like [QUnit](https://qunitjs.com/) and [karma-qunit](https://github.com/karma-runner/karma-qunit).
+```shell
+npm install --save-dev qunit karma-qunit
+```
+
+To use test spies, stubs and mocks you need to install [Sinon.JS](https://sinonjs.org/) and [karma-sinon](https://github.com/yanoosh/karma-sinon).
+```shell
+npm install --save-dev sinon karma-sinon
+```
+
+Both frameworks need to be added to the `karma.conf.js`.  
+Note that `ui5` should be the first entry.
+```js
+frameworks: ["ui5", "qunit", "sinon"]
+```
+
+Next, you need to provide the UI5 bootstrap configuration (see [config](#config)).  
+The `resourceRoots` configuration should be aligned with your project namespace.
+```js
+ui5: {
+  config: {
+    async: true,
+    resourceRoots: {
+      "sap.ui.demo.todo": "./base/webapp"
+    }
+  }
+}
+```
+
+Last but not least the test modules need to be listed, so that they are executed.
+```js
+ui5: {
+  tests: [
+    "sap/ui/demo/todo/test/unit/AllTests"
+  ]
+}
+```
+
+Here is the full example for the `script` mode:
+```js
+module.exports = function(config) {
+  config.set({
+    frameworks: ["ui5", "qunit", "sinon"],
+    ui5: {
+      url: "https://openui5.hana.ondemand.com",
+      mode: "script",
+      config: {
+        async: true,
+        resourceRoots: {
+          "sap.ui.demo.todo": "./base/webapp"
+        }
+      },
+      tests: [
+        "sap/ui/demo/todo/test/unit/AllTests"
+      ]
+    },
+    browsers: ["Chrome"]
+  });
+};
+```
+
 ### Execution
 
 With the above configuration, karma will by default run all tests in Chrome and listen for changed files to execute them again (watch mode).
@@ -124,69 +196,6 @@ There is an important requirement for using this plugin:
 
 - The karma `basePath` option **must point to your project root, not to a subfolder** like "webapp". This is the default when your `karma.conf.js` is in the project root.  
 It is required for the [type detection](#type) and automatic inclusion of your project files.
-
-## mode
-Type: `enum` (`"html"` / `"script"`)  
-Default: `"html"`
-
-Configures the mode how tests should be executed.
-
-### html
-
-The HTML mode runs QUnit test suites and test pages in a separate context.  
-It has built-in support for QUnit. The [QUnit adapter](https://github.com/karma-runner/karma-qunit) **must not be used** in combination with this mode. Other framework plugins must also **not** be used. Instead, the required libraries such as sinon should be loaded within the test.
-
-```js
-ui5: {
-  mode: "html"
-}
-```
-
-Specific config options:
-- [testpage](#testpage)
-- [urlParameters](#urlParameters)
-
-### script
-
-The script mode includes the UI5 bootstrap script. It allows to pass UI5 config and loads your test modules.  
-You need to also install and configure an adapter for your test framework such as [QUnit](https://github.com/karma-runner/karma-qunit), to enable test execution and reporting.
-
-```js
-ui5: {
-  mode: "script"
-}
-```
-
-Specific config options:
-- [config](#config)
-- [tests](#tests)
-
-#### Minimum running configuration example
-
-This is a minimalistic example configuration including the adapters for [QUnit](https://github.com/karma-runner/karma-qunit) and [Sinon.js](https://github.com/yanoosh/karma-sinon) in script mode.
-Since the dependencies in script mode are not declared in some html files, they have to be installed additionally: <br>
-`npm install --save-dev qunit karma-qunit sinon karma-sinon`
-
-By default, there is no further configuration necessary for the QUnit and Sinon.js adapters.
-
-```js
-frameworks: ["ui5", "qunit", "sinon"],
-ui5: {
-  url: "https://sapui5.hana.ondemand.com",
-  mode: "script",
-  config: {
-    async: true,
-    resourceRoots: {
-      "sap.ui.demo.todo": "./base/webapp"
-    }
-  },
-  tests: [
-    "sap/ui/demo/todo/test/unit/AllTests"
-  ]
-},
-
-```
-
 
 ## Options
 
@@ -278,6 +287,42 @@ ui5: {
   configPath: "ui5-test.yaml"
 }
 ```
+
+### mode
+Type: `enum` (`"html"` / `"script"`)  
+Default: `"html"`
+
+Configures the mode how tests should be executed.
+
+#### html
+
+The HTML mode runs QUnit test suites and test pages in a separate context.  
+It has built-in support for QUnit. The [QUnit adapter](https://github.com/karma-runner/karma-qunit) **must not be used** in combination with this mode. Other framework plugins must also **not** be used. Instead, the required libraries such as sinon should be loaded within the test.
+
+```js
+ui5: {
+  mode: "html"
+}
+```
+
+Specific config options:
+- [testpage](#testpage)
+- [urlParameters](#urlParameters)
+
+#### script
+
+The script mode includes the UI5 bootstrap script. It allows to pass UI5 config and loads your test modules.  
+You need to also install and configure an adapter for your test framework such as [QUnit](https://github.com/karma-runner/karma-qunit), to enable test execution and reporting.
+
+```js
+ui5: {
+  mode: "script"
+}
+```
+
+Specific config options:
+- [config](#config)
+- [tests](#tests)
 
 ### testpage
 Type: `string`  

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@
 	- [Configuration](#configuration)
 	- [Execution](#execution)
 - [Karma Configuration Requirements](#karma-configuration-requirements)
+- [mode](#mode)
+	- [html](#html)
+	- [script](#script)
+      - [Minimum running configuration example](#minimum-running-configuration-example)
 - [Options](#options)
 	- [url](#url)
 	- [type](#type)
 	- [paths](#paths)
 	- [configPath](#configpath)
-	- [mode](#mode)
-		- [html](#html)
-		- [script](#script)
 	- [testpage](#testpage)
 	- [urlParameters](#urlparameters)
 	- [config](#config)
@@ -124,6 +125,69 @@ There is an important requirement for using this plugin:
 - The karma `basePath` option **must point to your project root, not to a subfolder** like "webapp". This is the default when your `karma.conf.js` is in the project root.  
 It is required for the [type detection](#type) and automatic inclusion of your project files.
 
+## mode
+Type: `enum` (`"html"` / `"script"`)  
+Default: `"html"`
+
+Configures the mode how tests should be executed.
+
+### html
+
+The HTML mode runs QUnit test suites and test pages in a separate context.  
+It has built-in support for QUnit. The [QUnit adapter](https://github.com/karma-runner/karma-qunit) **must not be used** in combination with this mode. Other framework plugins must also **not** be used. Instead, the required libraries such as sinon should be loaded within the test.
+
+```js
+ui5: {
+  mode: "html"
+}
+```
+
+Specific config options:
+- [testpage](#testpage)
+- [urlParameters](#urlParameters)
+
+### script
+
+The script mode includes the UI5 bootstrap script. It allows to pass UI5 config and loads your test modules.  
+You need to also install and configure an adapter for your test framework such as [QUnit](https://github.com/karma-runner/karma-qunit), to enable test execution and reporting.
+
+```js
+ui5: {
+  mode: "script"
+}
+```
+
+Specific config options:
+- [config](#config)
+- [tests](#tests)
+
+#### Minimum running configuration example
+
+This is a minimalistic example configuration including the adapters for [QUnit](https://github.com/karma-runner/karma-qunit) and [Sinon.js](https://github.com/yanoosh/karma-sinon) in script mode.
+Since the dependencies in script mode are not declared in some html files, they have to be installed additionally: <br>
+`npm install --save-dev qunit karma-qunit sinon karma-sinon`
+
+By default, there is no further configuration necessary for the QUnit and Sinon.js adapters.
+
+```js
+frameworks: ["ui5", "qunit", "sinon"],
+ui5: {
+  url: "https://sapui5.hana.ondemand.com",
+  mode: "script",
+  config: {
+    async: true,
+    resourceRoots: {
+      "sap.ui.demo.todo": "./base/webapp"
+    }
+  },
+  tests: [
+    "sap/ui/demo/todo/test/unit/AllTests"
+  ]
+},
+
+```
+
+
 ## Options
 
 All configuration options need to be defined in an `ui5` object in your Karma configuration:
@@ -214,42 +278,6 @@ ui5: {
   configPath: "ui5-test.yaml"
 }
 ```
-
-### mode
-Type: `enum` (`"html"` / `"script"`)  
-Default: `"html"`
-
-Configures the mode how tests should be executed.
-
-#### html
-
-The HTML mode runs QUnit test suites and test pages in a separate context.  
-It has built-in support for QUnit. The [QUnit adapter](https://github.com/karma-runner/karma-qunit) **must not be used** in combination with this mode. Other framework plugins must also **not** be used. Instead, the required libraries such as sinon should be loaded within the test.
-
-```js
-ui5: {
-  mode: "html"
-}
-```
-
-Specific config options:
-- [testpage](#testpage)
-- [urlParameters](#urlParameters)
-
-#### script
-
-The script mode includes the UI5 bootstrap script. It allows to pass UI5 config and loads your test modules.  
-You need to also install and configure an adapter for your test framework such as [QUnit](https://github.com/karma-runner/karma-qunit), to enable test execution and reporting.
-
-```js
-ui5: {
-  mode: "script"
-}
-```
-
-Specific config options:
-- [config](#config)
-- [tests](#tests)
 
 ### testpage
 Type: `string`  


### PR DESCRIPTION
I had some trouble the other day setting up karma-ui5 in script mode.
I was missing a minimum running example for script mode.
After half a day try-and-error, I found one.
Maybe you also find this helpful for the readme.

I also moved the "mode" section out of "Options" because I think is is a crucial option that stands above all the other options.