### PR TITLE
[FIX] HTML mode: QUnit.config.noglobals with coverage enabled

### DIFF
--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -218,6 +218,30 @@ require("./discovery.js");
 					QUnit.testStart(function(test) {
 						timer = new Date().getTime();
 						testResult = {success: true, errors: []};
+
+						// Prevent false-positives when the "noglobals" config is enabled.
+						// Code instrumented by istanbul introduces global variables
+						// (cov_* for each file and a global __coverage__ variable).
+						// Adding them to the already collected "pollution" list prevents issues
+						// when the original "after" hook compares the list with the current state.
+						const config = QUnit.config;
+						if (!config.noglobals) {
+							return;
+						}
+						const currentTest = config.current;
+						const originalAfter = currentTest.after;
+						currentTest.after = function(...args) {
+							for (const key in testWindow.contentWindow) {
+								if (
+									Object.prototype.hasOwnProperty.call(testWindow.contentWindow, key) &&
+									(key.startsWith("cov_") || key === "__coverage__") &&
+									!config.pollution.includes(key)
+								) {
+									config.pollution.push(key);
+								}
+							}
+							return originalAfter.apply(currentTest, args);
+						};
 					});
 
 					QUnit.log(function(details) {

--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -234,8 +234,8 @@ require("./discovery.js");
 							for (const key in testWindow.contentWindow) {
 								if (
 									Object.prototype.hasOwnProperty.call(testWindow.contentWindow, key) &&
-									(key.startsWith("cov_") || key === "__coverage__") &&
-									!config.pollution.includes(key)
+									(key.indexOf("cov_") === 0 || key === "__coverage__") &&
+									config.pollution.indexOf(key) === -1
 								) {
 									config.pollution.push(key);
 								}

--- a/test/integration/application-proxy/webapp/test/test.qunit.js
+++ b/test/integration/application-proxy/webapp/test/test.qunit.js
@@ -5,11 +5,24 @@ QUnit.config.autostart = false;
 sap.ui.getCore().attachInit(function() {
 	"use strict";
 
-	sap.ui.require(["test/app/foo"], function() {
-		QUnit.test("Karma", function(assert) {
-			assert.ok(parent.__karma__.files["/base/webapp/.dotfile"], "Karma files should contain dotfiles");
-		});
-
-		QUnit.start();
+	QUnit.test("Karma", function(assert) {
+		assert.ok(parent.__karma__.files["/base/webapp/.dotfile"], "Karma files should contain dotfiles");
 	});
+
+	QUnit.test(
+		"Loading files during a test should not result into 'Introduced global variable(s)' issues " +
+		"when QUnit.config.noglobals is active",
+		function(assert) {
+			const done = assert.async();
+			sap.ui.require(["test/app/foo"], function() {
+				assert.ok(true, "test/app/foo has been loaded");
+				done();
+			}, function(err) {
+				assert.ok(false, "Failed to load test/app/foo: " + err);
+			});
+		}
+	);
+	QUnit.config.noglobals = true;
+
+	QUnit.start();
 });


### PR DESCRIPTION
Code instrumented by istanbul introduces global variables
(cov_* for each file and a global __coverage__ variable).
This causes a failure when the "noglobals" QUnit config is active and
some file is loaded during a test as this pollutes the global namespace.

Hooking into the "after" function allows to add those variables to the
list of known globals so that they won't be detected as new globals.