### PR TITLE
[FEATURE] Add "failOnEmptyTestPage" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 		- [script](#script)
 	- [testpage](#testpage)
 	- [urlParameters](#urlparameters)
+	- [failOnEmptyTestPage](#failonemptytestpage)
 	- [config](#config)
 	- [tests](#tests)
 - [API](#api)
@@ -236,6 +237,7 @@ ui5: {
 Specific config options:
 - [testpage](#testpage)
 - [urlParameters](#urlParameters)
+- [failOnEmptyTestPage](#failonemptytestpage)
 
 #### script
 
@@ -285,6 +287,23 @@ ui5: {
         key: "hidepassed",
         value: true
     }]
+}
+```
+
+### failOnEmptyTestPage
+Type: `boolean`  
+Default: `false`  
+CLI: `--ui5.failOnEmptyTestPage`  
+Specific to ["html" mode](#html)
+
+Reports an error when a test page does not define any tests.  
+The [Karma configuration `failOnEmptyTestSuite`](https://karma-runner.github.io/latest/config/configuration-file.html) only covers the case when no tests were defined at all, but not when just one testpage doesn't define tests.
+
+Example:
+```js
+ui5: {
+		mode: "html",
+		failOnEmptyTestPage: true
 }
 ```
 

--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -210,7 +210,7 @@ require("./discovery.js");
 						QUnit.begin(function(args) {
 							totalNumberOfTest += args.totalTests;
 							karma.info({total: totalNumberOfTest});
-							if(config.failOnNoTests && args.totalTests < 1) {
+							if (config.failOnNoTests && args.totalTests < 1) {
 								karma.result({
 									description: qunitHtmlFile,
 									suite: [],

--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -208,18 +208,30 @@ require("./discovery.js");
 
 					if (QUnit.begin) {
 						QUnit.begin(function(args) {
-							totalNumberOfTest += args.totalTests;
-							karma.info({total: totalNumberOfTest});
-							if (config.failOnEmptyTestPage && args.totalTests < 1) {
-								totalNumberOfTest += 1;
-								karma.result({
-									description: qunitHtmlFile,
-									suite: [],
-									success: false,
-									log: ["The test " + qunitHtmlFile + " executed successfully but did not report any tests at all. Please review your test content!"],
-									time: 0
-								});
+							if (args.totalTests === 0) {
+								if (config.failOnEmptyTestPage) {
+									totalNumberOfTest += 1;
+									karma.result({
+										description: qunitHtmlFile,
+										suite: [],
+										success: false,
+										log: ["Testpage did not define any tests."],
+										time: 0
+									});
+								} else {
+									// Don't report an error when option is not active
+									// Can't be activated by default because of compatibility reasons
+									karma.log("error", [
+										"Testpage \"" + qunitHtmlFile + "\" did not define any tests.\n" +
+										"Please consider enabling the \"failOnEmptyTestPage\" option " +
+										"in your karma config or via CLI to fail the test run:\n" +
+										"https://github.com/SAP/karma-ui5#failonemptytestpage"
+									]);
+								}
+							} else {
+								totalNumberOfTest += args.totalTests;
 							}
+							karma.info({total: totalNumberOfTest});
 						});
 					}
 

--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -210,6 +210,16 @@ require("./discovery.js");
 						QUnit.begin(function(args) {
 							totalNumberOfTest += args.totalTests;
 							karma.info({total: totalNumberOfTest});
+							if(config.failOnNoTests && args.totalTests < 1) {
+								karma.result({
+									description: qunitHtmlFile,
+									suite: [],
+									success: false,
+									log: ["Test suite with no tests are not allowed"],
+									time: 0
+								});
+								karma.complete({});
+							}
 						});
 					}
 

--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -215,10 +215,9 @@ require("./discovery.js");
 									description: qunitHtmlFile,
 									suite: [],
 									success: false,
-									log: ["Test suite with no tests are not allowed"],
+									log: ["The test " + qunitHtmlFile + " executed successfully but did not report any tests at all. Please review your test content!"],
 									time: 0
 								});
-								karma.complete({});
 							}
 						});
 					}

--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -210,7 +210,8 @@ require("./discovery.js");
 						QUnit.begin(function(args) {
 							totalNumberOfTest += args.totalTests;
 							karma.info({total: totalNumberOfTest});
-							if (config.failOnNoTests && args.totalTests < 1) {
+							if (config.failOnEmptyTestPage && args.totalTests < 1) {
+								totalNumberOfTest += 1;
 								karma.result({
 									description: qunitHtmlFile,
 									suite: [],

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -241,6 +241,32 @@ module.exports = function(config) {
 };
 `,
 
+		failOnEmptyTestPageNotTypeBoolean: (failOnEmptyTestPage) => `error 19:
+The failOnEmptyTestPage configuration must be of type "boolean"
+but found type "${typeof failOnEmptyTestPage}".
+
+module.exports = function(config) {
+	config.set({
+		ui5: {
+			failOnEmptyTestPage: ${JSON.stringify(failOnEmptyTestPage, null, "\t")}
+		}
+	});
+};`,
+
+		failOnEmptyTestPageInNonHtmlMode: (mode) => `error 20:
+The failOnEmptyTestPage configuration can only be used in "html" mode
+
+module.exports = function(config) {
+	config.set({
+		ui5: {
+			mode: "${mode}"
+
+			// Cannot be used in combination with mode "${mode}":
+			failOnEmptyTestPage: true
+		}
+	});
+};`,
+
 		failure: () => "ui5.framework failed. See error message above"
 
 	}

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -128,7 +128,8 @@ class Framework {
 		if (!this.config.ui5.mode) {
 			this.config.ui5.mode = "html";
 		}
-		if (!this.config.ui5.failOnEmptyTestPage) {
+		if (typeof this.config.ui5.failOnEmptyTestPage === "undefined") {
+			// TODO 3.0: Enable by default
 			this.config.ui5.failOnEmptyTestPage = false;
 		}
 
@@ -180,6 +181,23 @@ class Framework {
 			});
 		}
 
+		if (this.config.ui5.urlParameters !== undefined && !Array.isArray(this.config.ui5.urlParameters)) {
+			this.logger.log("error", ErrorMessage.urlParametersNotAnArray(this.config.ui5.urlParameters));
+			throw new Error(ErrorMessage.failure());
+		}
+
+		if (typeof this.config.ui5.failOnEmptyTestPage !== "boolean") {
+			this.logger.log(
+				"error",
+				ErrorMessage.failOnEmptyTestPageNotTypeBoolean(this.config.ui5.failOnEmptyTestPage)
+			);
+			throw new Error(ErrorMessage.failure());
+		}
+		if (this.config.ui5.mode !== "html" && this.config.ui5.failOnEmptyTestPage === true) {
+			this.logger.log("error", ErrorMessage.failOnEmptyTestPageInNonHtmlMode(this.config.ui5.mode));
+			throw new Error(ErrorMessage.failure());
+		}
+
 		this.config.ui5.paths = this.config.ui5.paths || {
 			webapp: "webapp",
 			src: "src",
@@ -228,12 +246,8 @@ class Framework {
 
 		// Make testpage url available to the client
 		this.config.client.ui5.testpage = this.config.ui5.testpage;
-		// Make no tests failure setting available to the client based on mode selected by user. User can set failOnEmptyTestPage only html mode
-		if (this.config.ui5.mode === "html") {
-			this.config.client.ui5.failOnEmptyTestPage = this.config.ui5.failOnEmptyTestPage;
-		} else {
-			this.config.client.ui5.failOnEmptyTestPage = false;
-		}
+		// Make failOnEmptyTestPage option available to the client
+		this.config.client.ui5.failOnEmptyTestPage = this.config.ui5.failOnEmptyTestPage;
 		// Pass configured urlParameters to client
 		this.config.client.ui5.urlParameters = this.config.ui5.urlParameters;
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -228,10 +228,8 @@ class Framework {
 
 		// Make testpage url available to the client
 		this.config.client.ui5.testpage = this.config.ui5.testpage;
-		
 		// Make no tests failure setting available to the client
 		this.config.client.ui5.failOnNoTests = this.config.ui5.failOnNoTests;
-
 		// Pass configured urlParameters to client
 		this.config.client.ui5.urlParameters = this.config.ui5.urlParameters;
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -128,8 +128,8 @@ class Framework {
 		if (!this.config.ui5.mode) {
 			this.config.ui5.mode = "html";
 		}
-		if (!this.config.ui5.failOnNoTests) {
-			this.config.ui5.failOnNoTests = false;
+		if (!this.config.ui5.failOnEmptyTestPage) {
+			this.config.ui5.failOnEmptyTestPage = false;
 		}
 
 		this.checkLegacy(config);
@@ -228,8 +228,12 @@ class Framework {
 
 		// Make testpage url available to the client
 		this.config.client.ui5.testpage = this.config.ui5.testpage;
-		// Make no tests failure setting available to the client
-		this.config.client.ui5.failOnNoTests = this.config.ui5.failOnNoTests;
+		// Make no tests failure setting available to the client based on mode selected by user. User can set failOnEmptyTestPage only html mode 
+		if (this.config.ui5.mode === "html") {
+			this.config.client.ui5.failOnEmptyTestPage = this.config.ui5.failOnEmptyTestPage;
+		} else {
+		        this.config.client.ui5.failOnEmptyTestPage = false;
+		}
 		// Pass configured urlParameters to client
 		this.config.client.ui5.urlParameters = this.config.ui5.urlParameters;
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -128,7 +128,7 @@ class Framework {
 		if (!this.config.ui5.mode) {
 			this.config.ui5.mode = "html";
 		}
-	        if (!this.config.ui5.failOnNoTests) {
+		if (!this.config.ui5.failOnNoTests) {
 			this.config.ui5.failOnNoTests = false;
 		}
 
@@ -229,8 +229,7 @@ class Framework {
 		// Make testpage url available to the client
 		this.config.client.ui5.testpage = this.config.ui5.testpage;
 		
-	        // Make no tests failure setting available to the client
-
+		// Make no tests failure setting available to the client
 		this.config.client.ui5.failOnNoTests = this.config.ui5.failOnNoTests;
 
 		// Pass configured urlParameters to client

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -228,11 +228,11 @@ class Framework {
 
 		// Make testpage url available to the client
 		this.config.client.ui5.testpage = this.config.ui5.testpage;
-		// Make no tests failure setting available to the client based on mode selected by user. User can set failOnEmptyTestPage only html mode 
+		// Make no tests failure setting available to the client based on mode selected by user. User can set failOnEmptyTestPage only html mode
 		if (this.config.ui5.mode === "html") {
 			this.config.client.ui5.failOnEmptyTestPage = this.config.ui5.failOnEmptyTestPage;
 		} else {
-		        this.config.client.ui5.failOnEmptyTestPage = false;
+			this.config.client.ui5.failOnEmptyTestPage = false;
 		}
 		// Pass configured urlParameters to client
 		this.config.client.ui5.urlParameters = this.config.ui5.urlParameters;

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -128,6 +128,9 @@ class Framework {
 		if (!this.config.ui5.mode) {
 			this.config.ui5.mode = "html";
 		}
+	        if (!this.config.ui5.failOnNoTests) {
+			this.config.ui5.failOnNoTests = false;
+		}
 
 		this.checkLegacy(config);
 
@@ -225,6 +228,10 @@ class Framework {
 
 		// Make testpage url available to the client
 		this.config.client.ui5.testpage = this.config.ui5.testpage;
+		
+	        // Make no tests failure setting available to the client
+
+		this.config.client.ui5.failOnNoTests = this.config.ui5.failOnNoTests;
 
 		// Pass configured urlParameters to client
 		this.config.client.ui5.urlParameters = this.config.ui5.urlParameters;

--- a/test/integration/application-ui5-tooling-error-handling/karma-failOnEmptyTestPage-false.conf.js
+++ b/test/integration/application-ui5-tooling-error-handling/karma-failOnEmptyTestPage-false.conf.js
@@ -1,0 +1,25 @@
+module.exports = function(config) {
+	"use strict";
+
+	require("../karma-base.conf")(config);
+	config.set({
+
+		frameworks: ["ui5"],
+
+		ui5: {
+			failOnEmptyTestPage: false,
+			testpage: "webapp/test/empty-testpage/testsuite.qunit.html"
+		}
+
+	});
+
+	require("../saucelabs").setTestName(config, __filename);
+};
+
+module.exports.shouldFail = false;
+module.exports.assertions = ({expect, log}) => {
+	expect(log).toMatch(/Executed 1 of 1/);
+	expect(log).toMatch(/TOTAL: 1 SUCCESS/);
+	expect(log).toMatch(/Testpage "\/base\/webapp\/test\/empty-testpage\/empty.qunit.html" did not define any tests/);
+	expect(log).toMatch(/Please consider enabling the "failOnEmptyTestPage" option/);
+};

--- a/test/integration/application-ui5-tooling-error-handling/karma-failOnEmptyTestPage-true.conf.js
+++ b/test/integration/application-ui5-tooling-error-handling/karma-failOnEmptyTestPage-true.conf.js
@@ -1,0 +1,25 @@
+module.exports = function(config) {
+	"use strict";
+
+	require("../karma-base.conf")(config);
+	config.set({
+
+		frameworks: ["ui5"],
+
+		ui5: {
+			failOnEmptyTestPage: true,
+			testpage: "webapp/test/empty-testpage/testsuite.qunit.html"
+		}
+
+	});
+
+	require("../saucelabs").setTestName(config, __filename);
+};
+
+module.exports.shouldFail = true;
+module.exports.assertions = ({expect, log}) => {
+	expect(log).toMatch(/Executed 2 of 2/);
+	expect(log).toMatch(/TOTAL: 1 FAILED, 1 SUCCESS/);
+	expect(log).toMatch(/\/base\/webapp\/test\/empty-testpage\/empty.qunit.html FAILED/);
+	expect(log).toMatch(/Testpage did not define any tests./);
+};

--- a/test/integration/application-ui5-tooling-error-handling/karma-failOnEmptyTestPage-with-script-mode.conf.js
+++ b/test/integration/application-ui5-tooling-error-handling/karma-failOnEmptyTestPage-with-script-mode.conf.js
@@ -1,0 +1,23 @@
+module.exports = function(config) {
+	"use strict";
+
+	require("../karma-base.conf")(config);
+	config.set({
+
+		frameworks: ["ui5"],
+
+		ui5: {
+			mode: "script",
+			// Can only be used in html mode
+			failOnEmptyTestPage: true
+		}
+
+	});
+
+	require("../saucelabs").setTestName(config, __filename);
+};
+
+module.exports.shouldFail = true;
+module.exports.assertions = ({expect, log}) => {
+	expect(log).toMatch(/The failOnEmptyTestPage configuration can only be used in "html" mode/);
+};

--- a/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/empty.qunit.html
+++ b/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/empty.qunit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>QUnit Test</title>
+
+	<script id="sap-ui-bootstrap" src="../../resources/sap-ui-core.js"></script>
+	<link rel="stylesheet" href="../../resources/sap/ui/thirdparty/qunit-2.css">
+	<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+	<script>
+		// No tests defined
+	</script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/test.qunit.html
+++ b/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/test.qunit.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>QUnit Test</title>
+
+	<script id="sap-ui-bootstrap" src="../../resources/sap-ui-core.js"></script>
+	<link rel="stylesheet" href="../../resources/sap/ui/thirdparty/qunit-2.css">
+	<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+	<script>
+		QUnit.test("Dummy", function(assert) {
+			assert.ok(true);
+		});
+	</script>
+</head>
+<body>
+	<div id="qunit"></div>
+</body>
+</html>

--- a/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/testsuite.qunit.html
+++ b/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/testsuite.qunit.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Testsuite</title>
+	<script src="testsuite.qunit.js" data-sap-ui-testsuite></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/testsuite.qunit.js
+++ b/test/integration/application-ui5-tooling-error-handling/webapp/test/empty-testpage/testsuite.qunit.js
@@ -1,0 +1,11 @@
+window.suite = function() {
+	"use strict";
+
+	// eslint-disable-next-line new-cap
+	const oSuite = new parent.jsUnitTestSuite();
+	const sContextPath = location.pathname.substring(0, location.pathname.lastIndexOf("/") + 1);
+	oSuite.addTestPage(sContextPath + "test.qunit.html");
+	oSuite.addTestPage(sContextPath + "empty.qunit.html");
+
+	return oSuite;
+};

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -216,6 +216,7 @@ describe("UI5 Middleware / Proxy configuration", () => {
 		await framework.init({config, logger});
 
 		expect(setupProxySpy).toHaveBeenCalledWith({
+			failOnNoTests: false,
 			mode: "html",
 			url: "http://localhost",
 			type: "application",

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -684,6 +684,76 @@ describe("urlParameters", () => {
 	});
 });
 
+describe("failOnEmptyTestPage", () => {
+	it("should default to 'false'", async () => {
+		const config = {
+			ui5: {}
+		};
+		const framework = new Framework();
+		framework.exists = () => true;
+		framework.init({
+			config: config,
+			logger: logger
+		});
+
+		expect(config.ui5.failOnEmptyTestPage).toBe(false);
+	});
+	it("should pass 'true' value to client", async () => {
+		const config = {
+			ui5: {
+				failOnEmptyTestPage: true
+			}
+		};
+		const framework = new Framework();
+		framework.exists = () => true;
+		framework.init({
+			config: config,
+			logger: logger
+		});
+
+		expect(config.client.ui5.failOnEmptyTestPage).toBe(true);
+	});
+	it("should pass 'false' value to client", async () => {
+		const config = {
+			ui5: {
+				failOnEmptyTestPage: false
+			}
+		};
+		const framework = new Framework();
+		framework.exists = () => true;
+		framework.init({
+			config: config,
+			logger: logger
+		});
+
+		expect(config.client.ui5.failOnEmptyTestPage).toBe(false);
+	});
+	it("Should throw if failOnEmptyTestPage is not of type boolean (string)", async () => {
+		const config = {
+			ui5: {failOnEmptyTestPage: "true"}
+		};
+		const framework = new Framework();
+		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure());
+		expect(framework.logger.message).toBe(ErrorMessage.failOnEmptyTestPageNotTypeBoolean("true"));
+	});
+	it("Should throw if failOnEmptyTestPage is not of type boolean (object)", async () => {
+		const config = {
+			ui5: {failOnEmptyTestPage: {foo: "bar"}}
+		};
+		const framework = new Framework();
+		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure());
+		expect(framework.logger.message).toBe(ErrorMessage.failOnEmptyTestPageNotTypeBoolean({foo: "bar"}));
+	});
+	it("Should throw if failOnEmptyTestPage is used with script mode", async () => {
+		const config = {
+			ui5: {mode: "script", failOnEmptyTestPage: true}
+		};
+		const framework = new Framework();
+		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure());
+		expect(framework.logger.message).toBe(ErrorMessage.failOnEmptyTestPageInNonHtmlMode("script"));
+	});
+});
+
 describe("Without QUnit HTML Runner (with URL)", () => {
 	it("Should include sap-ui-config.js and sap-ui-core.js", async () => {
 		const config = {

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -216,7 +216,7 @@ describe("UI5 Middleware / Proxy configuration", () => {
 		await framework.init({config, logger});
 
 		expect(setupProxySpy).toHaveBeenCalledWith({
-			failOnNoTests: false,
+			failOnEmptyTestPage: false,
 			mode: "html",
 			url: "http://localhost",
 			type: "application",


### PR DESCRIPTION
https://github.com/SAP/karma-ui5/issues/226

Hi colleagues,
In S4 if some team has qunit and opa tests defined and loaded but OPA tests contains no tests or assertion, than runner should fail with error of "Suite with no tests should be removed". This happened when someone comment out testfiles in Alljourneys and runner still loads Alljourney but than reports no tests. In this case we see low coverages and team complains about it. So we want to configure runner so that we centrally can define some parameter in karma conf file to enable or disable failure in case of no tests.

Thanks