### PR TITLE
[INTERNAL] Replace insensitive terms with inclusive language

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 module.exports = {
 	ErrorMessage: {
-		excludedFrameworks: (frameworks) => {
+		incompatibleFrameworks: (frameworks) => {
 			let errorMessage = "error 1:\nThe \"karma-ui5\" plugin is not compatible " +
 				"with certain framework plugins when running in \"html\" mode.";
 			if (frameworks.includes("qunit")) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 module.exports = {
 	ErrorMessage: {
-		blacklistedFrameworks: (frameworks) => {
+		excludedFrameworks: (frameworks) => {
 			let errorMessage = "error 1:\nThe \"karma-ui5\" plugin is not compatible " +
 				"with certain framework plugins when running in \"html\" mode.";
 			if (frameworks.includes("qunit")) {

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -138,10 +138,10 @@ class Framework {
 			throw new Error(ErrorMessage.failure());
 		}
 
-		const excludedFrameworks = ["qunit", "sinon"];
-		const hasExcludedFrameworks = (frameworks) => frameworks.some((fwk) => excludedFrameworks.includes(fwk));
-		if (this.config.ui5.mode === "html" && hasExcludedFrameworks(this.config.frameworks || [])) {
-			this.logger.log("error", ErrorMessage.excludedFrameworks(this.config.frameworks) );
+		const incompatibleFrameworks = ["qunit", "sinon"];
+		const hasIncompatibleFrameworks = (frameworks) => frameworks.some((fwk) => incompatibleFrameworks.includes(fwk));
+		if (this.config.ui5.mode === "html" && hasIncompatibleFrameworks(this.config.frameworks || [])) {
+			this.logger.log("error", ErrorMessage.incompatibleFrameworks(this.config.frameworks) );
 			throw new Error(ErrorMessage.failure());
 		}
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -138,10 +138,10 @@ class Framework {
 			throw new Error(ErrorMessage.failure());
 		}
 
-		const blacklistedFrameworks = ["qunit", "sinon"];
-		const hasBlacklistedFrameworks = (frameworks) => frameworks.some((fwk) => blacklistedFrameworks.includes(fwk));
-		if (this.config.ui5.mode === "html" && hasBlacklistedFrameworks(this.config.frameworks || [])) {
-			this.logger.log("error", ErrorMessage.blacklistedFrameworks(this.config.frameworks) );
+		const excludedFrameworks = ["qunit", "sinon"];
+		const hasExcludedFrameworks = (frameworks) => frameworks.some((fwk) => excludedFrameworks.includes(fwk));
+		if (this.config.ui5.mode === "html" && hasExcludedFrameworks(this.config.frameworks || [])) {
+			this.logger.log("error", ErrorMessage.excludedFrameworks(this.config.frameworks) );
 			throw new Error(ErrorMessage.failure());
 		}
 

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -1031,28 +1031,28 @@ describe("Error logging", () => {
 		}));
 	});
 
-	it("Should not throw if a non-excluded framework has been defined", async () => {
+	it("Should not throw if a compatible framework has been defined", async () => {
 		const config = {
 			frameworks: ["foo", "ui5"]
 		};
 		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure()); // some unrelated exception
-		expect(framework.logger.message).not.toBe(ErrorMessage.excludedFrameworks(["foo", "ui5"]));
+		expect(framework.logger.message).not.toBe(ErrorMessage.incompatibleFrameworks(["foo", "ui5"]));
 	});
 
-	it("Should throw if an excluded framework has been defined (qunit)", async () => {
+	it("Should throw if an incompatible framework has been defined (qunit)", async () => {
 		const config = {
 			frameworks: ["qunit", "ui5"]
 		};
 		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure());
-		expect(framework.logger.message).toBe(ErrorMessage.excludedFrameworks(["qunit", "ui5"]));
+		expect(framework.logger.message).toBe(ErrorMessage.incompatibleFrameworks(["qunit", "ui5"]));
 	});
 
-	it("Should throw if an excluded framework has been defined (qunit + sinon)", async () => {
+	it("Should throw if an incompatible framework has been defined (qunit + sinon)", async () => {
 		const config = {
 			frameworks: ["qunit", "sinon", "ui5"]
 		};
 		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure());
-		expect(framework.logger.message).toBe(ErrorMessage.excludedFrameworks(["qunit", "sinon", "ui5"]));
+		expect(framework.logger.message).toBe(ErrorMessage.incompatibleFrameworks(["qunit", "sinon", "ui5"]));
 	});
 
 	it("Should throw if files have been defined in config", async () => {

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -1031,28 +1031,28 @@ describe("Error logging", () => {
 		}));
 	});
 
-	it("Should not throw if a non-backlisted framework has been defined", async () => {
+	it("Should not throw if a non-excluded framework has been defined", async () => {
 		const config = {
 			frameworks: ["foo", "ui5"]
 		};
 		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure()); // some unrelated exception
-		expect(framework.logger.message).not.toBe(ErrorMessage.blacklistedFrameworks(["foo", "ui5"]));
+		expect(framework.logger.message).not.toBe(ErrorMessage.excludedFrameworks(["foo", "ui5"]));
 	});
 
-	it("Should throw if a blacklisted framework has been defined (qunit)", async () => {
+	it("Should throw if an excluded framework has been defined (qunit)", async () => {
 		const config = {
 			frameworks: ["qunit", "ui5"]
 		};
 		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure());
-		expect(framework.logger.message).toBe(ErrorMessage.blacklistedFrameworks(["qunit", "ui5"]));
+		expect(framework.logger.message).toBe(ErrorMessage.excludedFrameworks(["qunit", "ui5"]));
 	});
 
-	it("Should throw if a blacklisted framework has been defined (qunit + sinon)", async () => {
+	it("Should throw if an excluded framework has been defined (qunit + sinon)", async () => {
 		const config = {
 			frameworks: ["qunit", "sinon", "ui5"]
 		};
 		await expect(framework.init({config, logger})).rejects.toThrow(ErrorMessage.failure());
-		expect(framework.logger.message).toBe(ErrorMessage.blacklistedFrameworks(["qunit", "sinon", "ui5"]));
+		expect(framework.logger.message).toBe(ErrorMessage.excludedFrameworks(["qunit", "sinon", "ui5"]));
 	});
 
 	it("Should throw if files have been defined in config", async () => {


### PR DESCRIPTION
use appropriate terminology "incompatible", because the frameworks in the list are incompatible and should therefore be excluded.

Successor of #163 