### PR TITLE
[FIX] Creating multiple plugin instances

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -17,8 +17,6 @@ const {ErrorMessage} = require("./errors");
 class Framework {
 	constructor() {
 		this.config = {};
-		this.beforeMiddleware = new Router();
-		this.middleware = new Router();
 	}
 
 	createPluginFilesPattern(pattern) {
@@ -521,6 +519,9 @@ class Framework {
 
 	async setupMiddleware() {
 		const config = this.config;
+		
+		config.ui5._beforeMiddleware = this.beforeMiddleware = new Router();
+		config.ui5._middleware = this.middleware = new Router();
 
 		if (config.ui5.type === "library") {
 			this.beforeMiddleware.use(this.beforeMiddlewareRewriteUrl.bind(this));

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -519,12 +519,10 @@ class Framework {
 
 	async setupMiddleware() {
 		const config = this.config;
-		
-		config.ui5._beforeMiddleware = this.beforeMiddleware = new Router();
-		config.ui5._middleware = this.middleware = new Router();
 
 		if (config.ui5.type === "library") {
-			this.beforeMiddleware.use(this.beforeMiddlewareRewriteUrl.bind(this));
+			config.ui5._beforeMiddleware = new Router();
+			config.ui5._beforeMiddleware.use(this.beforeMiddlewareRewriteUrl.bind(this));
 			config.beforeMiddleware.push("ui5--beforeMiddleware");
 		}
 
@@ -539,8 +537,9 @@ class Framework {
 		}
 
 		if (middleware) {
-			this.middleware.use(this.middlewareRewriteUrl.bind(this));
-			this.middleware.use(middleware);
+			config.ui5._middleware = new Router();
+			config.ui5._middleware.use(this.middlewareRewriteUrl.bind(this));
+			config.ui5._middleware.use(middleware);
 			config.middleware.push("ui5--middleware");
 		}
 	}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
 const {ErrorMessage} = require("./errors");
 const Framework = require("./framework");
-const framework = new Framework();
 
 async function init(config, logger) {
 	try {
+		const framework = new Framework();
 		await framework.init({config, logger});
 	} catch (error) {
 		const _logger = logger.create("ui5.framework");
@@ -13,13 +13,13 @@ async function init(config, logger) {
 }
 init.$inject = ["config", "logger"];
 
-function getBeforeMiddleware(config) {
-	return config.ui5._beforeMiddleware;
+function getBeforeMiddleware(ui5) {
+	return ui5._beforeMiddleware;
 }
-function getMiddleware(config) {
-	return config.ui5._middleware;
+function getMiddleware(ui5) {
+	return ui5._middleware;
 }
-getBeforeMiddleware.$inject = getMiddleware.$inject = ["config"];
+getBeforeMiddleware.$inject = getMiddleware.$inject = ["config.ui5"];
 
 module.exports = {
 	"framework:ui5": ["factory", init],

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,11 +11,18 @@ async function init(config, logger) {
 		throw new Error(ErrorMessage.failure());
 	}
 }
-
 init.$inject = ["config", "logger"];
+
+function getBeforeMiddleware(config) {
+	return config.ui5._beforeMiddleware;
+}
+function getMiddleware(config) {
+	return config.ui5._middleware;
+}
+getBeforeMiddleware.$inject = getMiddleware.$inject = ["config"];
 
 module.exports = {
 	"framework:ui5": ["factory", init],
-	"middleware:ui5--beforeMiddleware": ["value", framework.beforeMiddleware],
-	"middleware:ui5--middleware": ["value", framework.middleware]
+	"middleware:ui5--beforeMiddleware": ["factory", getBeforeMiddleware],
+	"middleware:ui5--middleware": ["factory", getMiddleware]
 };

--- a/test/unit/framework.test.js
+++ b/test/unit/framework.test.js
@@ -37,7 +37,7 @@ describe("Middleware for UI5", () => {
 
 		const rewriteUrlBeforeSpy = jest.spyOn(framework, "rewriteUrlBefore");
 
-		const beforeMiddleware = framework.beforeMiddleware;
+		const beforeMiddleware = config.ui5._beforeMiddleware;
 
 		const req = {
 			url: "/foo"
@@ -71,7 +71,7 @@ describe("Middleware for UI5", () => {
 
 		const rewriteUrlSpy = jest.spyOn(framework, "rewriteUrl");
 
-		const middleware = framework.middleware;
+		const middleware = config.ui5._middleware;
 
 		const req = {
 			url: "/foo"
@@ -168,7 +168,8 @@ describe("UI5 Middleware / Proxy configuration", () => {
 				webapp: "webapp",
 				src: "src",
 				test: "test"
-			}
+			},
+			_middleware: expect.any(Function)
 		});
 	});
 

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -39,8 +39,15 @@ describe("Karma Plugin", () => {
 
 		await plugin["framework:ui5"][1](config1, logger1);
 
+		config1.ui5 = {
+			_middleware: jest.fn(),
+			_beforeMiddleware: jest.fn()
+		};
+
 		expect(frameworkInitStub).toHaveBeenCalledTimes(1);
 		expect(frameworkInitStub).toHaveBeenCalledWith({config: config1, logger: logger1});
+		expect(plugin["middleware:ui5--beforeMiddleware"][1](config1.ui5)).toBe(config1.ui5._beforeMiddleware);
+		expect(plugin["middleware:ui5--middleware"][1](config1.ui5)).toBe(config1.ui5._middleware);
 
 		const config2 = {};
 		const logger2 = {
@@ -53,7 +60,30 @@ describe("Karma Plugin", () => {
 
 		await plugin["framework:ui5"][1](config2, logger2);
 
+		config2.ui5 = {
+			_middleware: jest.fn(),
+			_beforeMiddleware: jest.fn()
+		};
+
 		expect(frameworkInitStub).toHaveBeenCalledTimes(2);
 		expect(frameworkInitStub).toHaveBeenCalledWith({config: config2, logger: logger2});
+		expect(plugin["middleware:ui5--beforeMiddleware"][1](config2.ui5)).toBe(config2.ui5._beforeMiddleware);
+		expect(plugin["middleware:ui5--middleware"][1](config2.ui5)).toBe(config2.ui5._middleware);
+	});
+	it("Should handle framework initialize error", async () => {
+		const Framework = require("../../lib/framework");
+		const plugin = require("../../");
+		jest.spyOn(Framework.prototype, "init").mockRejectedValue(new Error("Error from framework.init"));
+
+		const config = {};
+		const logger = {
+			create: jest.fn(() => {
+				return {
+					log: jest.fn()
+				};
+			})
+		};
+
+		await expect(plugin["framework:ui5"][1](config, logger)).rejects.toThrow("ss");
 	});
 });

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -13,7 +13,7 @@ describe("Karma Plugin", () => {
 		expect(plugin["middleware:ui5--beforeMiddleware"]).toHaveLength(2);
 		expect(plugin["middleware:ui5--beforeMiddleware"][0]).toBe("factory");
 		expect(plugin["middleware:ui5--beforeMiddleware"][1]).toStrictEqual(expect.any(Function));
-		expect(plugin["middleware:ui5--beforeMiddleware"][1].$inject).toStrictEqual(["config"]);
+		expect(plugin["middleware:ui5--beforeMiddleware"][1].$inject).toStrictEqual(["config.ui5"]);
 	});
 	it("Should export middleware:ui5--middleware", async () => {
 		const plugin = require("../../");
@@ -21,10 +21,39 @@ describe("Karma Plugin", () => {
 		expect(plugin["middleware:ui5--middleware"]).toHaveLength(2);
 		expect(plugin["middleware:ui5--middleware"][0]).toBe("factory");
 		expect(plugin["middleware:ui5--middleware"][1]).toStrictEqual(expect.any(Function));
-		expect(plugin["middleware:ui5--middleware"][1].$inject).toStrictEqual(["config"]);
+		expect(plugin["middleware:ui5--middleware"][1].$inject).toStrictEqual(["config.ui5"]);
 	});
-
-	it.skip("Should be able to initialize multiple times", async () => {
+	it("Should be able to initialize multiple times", async () => {
+		const Framework = require("../../lib/framework");
 		const plugin = require("../../");
+		const frameworkInitStub = jest.spyOn(Framework.prototype, "init").mockImplementation();
+
+		const config1 = {};
+		const logger1 = {
+			create: jest.fn(() => {
+				return {
+					log: jest.fn()
+				};
+			})
+		};
+
+		await plugin["framework:ui5"][1](config1, logger1);
+
+		expect(frameworkInitStub).toHaveBeenCalledTimes(1);
+		expect(frameworkInitStub).toHaveBeenCalledWith({config: config1, logger: logger1});
+
+		const config2 = {};
+		const logger2 = {
+			create: jest.fn(() => {
+				return {
+					log: jest.fn()
+				};
+			})
+		};
+
+		await plugin["framework:ui5"][1](config2, logger2);
+
+		expect(frameworkInitStub).toHaveBeenCalledTimes(2);
+		expect(frameworkInitStub).toHaveBeenCalledWith({config: config2, logger: logger2});
 	});
 });

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,0 +1,30 @@
+describe("Karma Plugin", () => {
+	it("Should export framework:ui5", async () => {
+		const plugin = require("../../");
+		expect(plugin["framework:ui5"]).toStrictEqual(expect.any(Array));
+		expect(plugin["framework:ui5"]).toHaveLength(2);
+		expect(plugin["framework:ui5"][0]).toBe("factory");
+		expect(plugin["framework:ui5"][1]).toStrictEqual(expect.any(Function));
+		expect(plugin["framework:ui5"][1].$inject).toStrictEqual(["config", "logger"]);
+	});
+	it("Should export middleware:ui5--beforeMiddleware", async () => {
+		const plugin = require("../../");
+		expect(plugin["middleware:ui5--beforeMiddleware"]).toStrictEqual(expect.any(Array));
+		expect(plugin["middleware:ui5--beforeMiddleware"]).toHaveLength(2);
+		expect(plugin["middleware:ui5--beforeMiddleware"][0]).toBe("factory");
+		expect(plugin["middleware:ui5--beforeMiddleware"][1]).toStrictEqual(expect.any(Function));
+		expect(plugin["middleware:ui5--beforeMiddleware"][1].$inject).toStrictEqual(["config"]);
+	});
+	it("Should export middleware:ui5--middleware", async () => {
+		const plugin = require("../../");
+		expect(plugin["middleware:ui5--middleware"]).toStrictEqual(expect.any(Array));
+		expect(plugin["middleware:ui5--middleware"]).toHaveLength(2);
+		expect(plugin["middleware:ui5--middleware"][0]).toBe("factory");
+		expect(plugin["middleware:ui5--middleware"][1]).toStrictEqual(expect.any(Function));
+		expect(plugin["middleware:ui5--middleware"][1].$inject).toStrictEqual(["config"]);
+	});
+
+	it.skip("Should be able to initialize multiple times", async () => {
+		const plugin = require("../../");
+	});
+});

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -14,9 +14,6 @@ module.exports = {
 			"lines": 90,
 			"statements": 90
 		},
-		"./lib/index.js": {
-			// TODO: Add unit test for index.js
-		},
 		"./lib/client/": {
 			// TODO: Add unit tests for client code
 		}


### PR DESCRIPTION
Recent changes in commit 762cde2e389c5293295377c8c372e1711d17bb14 caused that always the same UI5 middleware was returned, even for multiple KarmaServer instances. Karma however, initializes the plugins for each KarmaServer instance, which causes the same middleware to be added twice to the sub-router introduced in the mentioned commit. All in all this causes unexpected behaviour in tests, e.g. failing requests when sending PATCH requests.