### PR TITLE
[INTERNAL] SauceLabs: Run tests for IE11 with UI5 1.71

### DIFF
--- a/.github/workflows/saucelabs.yml
+++ b/.github/workflows/saucelabs.yml
@@ -1,4 +1,4 @@
-name: SauceLabs Integration Tests
+name: SauceLabs Integration Tests (UI5 1.71 / IE11)
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
 
-    name: SauceLabs Integration Tests
+    name: SauceLabs Integration Tests (UI5 1.71 / IE11)
 
     runs-on: ubuntu-latest
 
@@ -20,6 +20,8 @@ jobs:
       with:
         node-version: 14.x
     - run: npm ci
+    - name: Install @openui5/sap.ui.core@1.71.x
+      run: npm install -D @openui5/sap.ui.core@1.71.x
     - name: Start sauce-connect
       uses: saucelabs/sauce-connect-action@v1.1.3
       with:

--- a/test/integration/saucelabs.js
+++ b/test/integration/saucelabs.js
@@ -52,6 +52,7 @@ module.exports.setup = function(config) {
 			browserDisconnectTimeout: 300000, // 5 minutes
 			browserSocketTimeout: 120000, // 2 minutes
 			browserNoActivityTimeout: 300000, // 5 minutes
+			pingTimeout: 90000, // 90 seconds, see: https://github.com/karma-runner/karma/issues/3359#issuecomment-772699091
 
 			reporters: ["progress", "coverage", "saucelabs"]
 

--- a/test/integration/saucelabs.js
+++ b/test/integration/saucelabs.js
@@ -17,11 +17,6 @@ module.exports.setup = function(config) {
 		config.set({
 
 			customLaunchers: {
-				SauceLabs_firefox: {
-					base: "SauceLabs",
-					browserName: "firefox",
-					platformName: "Windows 10"
-				},
 				SauceLabs_ie11: {
 					base: "SauceLabs",
 					browserName: "internet explorer",
@@ -44,9 +39,10 @@ module.exports.setup = function(config) {
 				tunnelIdentifier: `github-${process.env.GITHUB_RUN_ID}`
 			},
 
-			// Running with 2 browsers in parallel is unstable.
-			// For now we only run on IE11.
-			// browsers: ["SauceLabs_firefox", "SauceLabs_ie11"],
+			// Running with IE11 to ensure legacy compatibility of karma-ui5
+			// UI5 dropped IE11 support starting with 1.88 (see https://blogs.sap.com/2021/02/02/internet-explorer-11-will-no-longer-be-supported-by-various-sap-ui-technologies-in-newer-releases/)
+			// But as this plugin should stay compatible with all maintained
+			// UI5 versions it still needs to be tested with IE11
 			browsers: ["SauceLabs_ie11"],
 
 			captureTimeout: 300000, // 5 minutes

--- a/test/integration/saucelabs.js
+++ b/test/integration/saucelabs.js
@@ -45,6 +45,8 @@ module.exports.setup = function(config) {
 			// UI5 versions it still needs to be tested with IE11
 			browsers: ["SauceLabs_ie11"],
 
+			logLevel: "DEBUG",
+
 			captureTimeout: 300000, // 5 minutes
 			browserDisconnectTolerance: 3,
 			browserDisconnectTimeout: 300000, // 5 minutes


### PR DESCRIPTION
UI5 dropped IE11 support starting with 1.88, which caused the existing
IE11 tests via SauceLabs to fail.

Now using 1.71 which still supports IE11 and is a long-term maintenance
release.
