### PR TITLE
[FIX] Adapt discovery to recent changes in OpenUI5

### DIFF
--- a/lib/client/discovery.js
+++ b/lib/client/discovery.js
@@ -59,7 +59,7 @@
 				// check for an existing test page and check for test suite or page
 				getFile(oTestPageConfig.fullpage).then(function(sData) {
 					if (/(?:window\.suite\s*=|function\s*suite\s*\(\s*\)\s*{)/.test(sData) ||
-							(/data-sap-ui-testsuite/.test(sData) && !/sap\/ui\/test\/starter\/runTest/.test(sData)) || 
+							(/data-sap-ui-testsuite/.test(sData) && !/sap\/ui\/test\/starter\/runTest/.test(sData)) ||
 							/sap\/ui\/test\/starter\/createSuite/.test(sData)) {
 						// console.log("execute page ", sTestPage);
 

--- a/lib/client/discovery.js
+++ b/lib/client/discovery.js
@@ -59,8 +59,8 @@
 				// check for an existing test page and check for test suite or page
 				getFile(oTestPageConfig.fullpage).then(function(sData) {
 					if (/(?:window\.suite\s*=|function\s*suite\s*\(\s*\)\s*{)/.test(sData) ||
-							(/data-sap-ui-testsuite/.test(sData) &&
-							!/sap\/ui\/test\/starter\/run-test/.test(sData)) ) {
+							(/data-sap-ui-testsuite/.test(sData) && !/sap\/ui\/test\/starter\/runTest/.test(sData)) || 
+							/sap\/ui\/test\/starter\/createSuite/.test(sData)) {
 						// console.log("execute page ", sTestPage);
 
 						const frame = document.createElement("iframe");


### PR DESCRIPTION
With https://github.com/SAP/openui5/commit/b8569e7a26ace55f68fad905ec4f5e22ba7a22d1, the set of possible 'signatures' of testsuites has been extended in OpenUI5. The discovery needs to be adapted to this extended set.