### PR TITLE
[INTERNAL] Pin license-webpack-plugin to 2.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8724,9 +8724,9 @@
 			}
 		},
 		"license-webpack-plugin": {
-			"version": "2.3.20",
-			"resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-2.3.20.tgz",
-			"integrity": "sha512-AHVueg9clOKACSHkhmEI+PCC9x8+qsQVuKECZD3ETxETK5h/PCv5/MUzyG1gm8OMcip/s1tcNxqo9Qb7WhjGsg==",
+			"version": "2.3.18",
+			"resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-2.3.18.tgz",
+			"integrity": "sha512-a6tSN07AgKkX9nVntBd9MP7OAzt7gKAcnXOy6xegH5y0012vVPNiglLdR0qrEIagg7TMAGhZi1WONiNOg8pe8w==",
 			"dev": true,
 			"requires": {
 				"@types/webpack-sources": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"karma-ie-launcher": "^1.0.0",
 		"karma-qunit": "^4.1.2",
 		"karma-sauce-launcher": "^4.3.6",
-		"license-webpack-plugin": "^2.3.20",
+		"license-webpack-plugin": "2.3.18",
 		"puppeteer": "^8.0.0",
 		"qunit": "^2.16.0",
 		"rimraf": "^3.0.2",


### PR DESCRIPTION
Prevents regression 'TypeError: item.node is not a function' with newer
webpack versions (5.47+).
