### PR TITLE
display full lists of tests

### DIFF
--- a/lib/client/browser.js
+++ b/lib/client/browser.js
@@ -98,6 +98,10 @@ require("./discovery.js");
 		config.testpage = prependBase(config.testpage);
 
 		window.findTests(config.testpage).then(function(testpages) {
+			const fullpageTests = testpages.map(testpage => testpage["fullpage"]);
+
+			karma.log("info", [fullpageTests]);
+
 			if (!testpages || testpages.length === 0) {
 				reportSetupFailure("Could not resolve any testpages!");
 				return;


### PR DESCRIPTION
To show info logs you need to change the browser console log level to info: 
browserConsoleLogOptions: {
	level: "info"
}