### PR TITLE
[INTERNAL] package-lock.json: Use colors@1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,9 +3840,9 @@
 			"dev": true
 		},
 		"colors": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.1.tgz",
-			"integrity": "sha512-urbBmMVnD1vk0mUwCpnWv06P3f16EF+RMTtIXTkylJk5mAdfrMepu9B3hhSnL8DGkc1Ra6pENJHrXTKvcAZ0wA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
 			"dev": true
 		},
 		"combined-stream": {


### PR DESCRIPTION
v1.4.1 has been removed from npm
