### PR TITLE
[INTERNAL] Update GitHub Actions CI

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     - uses: actions/checkout@v3.1.0
 
-    - name: Use Node.js LTS 14.x
+    - name: Use Node.js LTS 18.x
       uses: actions/setup-node@v2.5.0
       with:
-        node-version: 14.x
+        node-version: 18.x
 
     - name: Install dependencies
       run: npm ci
@@ -36,10 +36,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [14, 16, 18]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         include:
-          - node-version: 16
+          - node-version: 19
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -81,10 +81,10 @@ jobs:
 
     - uses: actions/checkout@v3.1.0
 
-    - name: Use Node.js LTS 14.x
+    - name: Use Node.js LTS 18.x
       uses: actions/setup-node@v2.5.0
       with:
-        node-version: 14.x
+        node-version: 18.x
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/saucelabs.yml
+++ b/.github/workflows/saucelabs.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3.1.0
-    - name: Use Node.js 14.x
+    - name: Use Node.js LTS 18.x
       uses: actions/setup-node@v2.5.0
       with:
-        node-version: 14.x
+        node-version: 18.x
     - run: npm ci
     - name: Install @openui5/sap.ui.core@1.71.x
       run: npm install -D @openui5/sap.ui.core@1.71.x

--- a/.github/workflows/saucelabs.yml
+++ b/.github/workflows/saucelabs.yml
@@ -1,5 +1,8 @@
 name: SauceLabs Integration Tests (UI5 1.71 / IE11)
 
+# Prevent multiple parallel executions as the OpenSauce account is quite limited
+concurrency: SauceLabs
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/saucelabs.yml
+++ b/.github/workflows/saucelabs.yml
@@ -31,7 +31,7 @@ jobs:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
         tunnelIdentifier: github-${{ github.run_id }}
-        restUrl: https://eu-central-1.saucelabs.com/rest/v1
+        region: eu-central
       # Prevents step from running for forks, which doesn't work as secrets are not available
       if: env.SAUCE_USERNAME != null
       env:


### PR DESCRIPTION
Dropping old Node.js versions to allow upgrading dependencies such as
puppeteer. This is a preparation for the next major release which will
drop support for old Node.js versions.
