### PR TITLE
[INTERNAL] Enforce correct commit message header for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
   - matz3
   - RandomByte
   versioning-strategy: increase
+  commit-message:
+    prefix: "[DEPENDENCY] "
+    prefix-development: "[INTERNAL] "


### PR DESCRIPTION
Aligned with the dependabot config of the UI5 Tooling repositories.