### PR TITLE
[INTERNAL] Enable enhanced inclusive language check

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,0 +1,1 @@
+_extends: ietf/terminology


### PR DESCRIPTION
This enables the advanced in-solidarity check which is already active for the UI5 Tooling repositories.

**Details:**
The inclusive language check is using https://github.com/ietf/terminology instead of the default set. With that more terms are declared as non inclusive.