### PR TITLE
[INTERNAL] Use native fs.mkdir instead of mkdirp

### DIFF
--- a/lib/fileExportReporter.js
+++ b/lib/fileExportReporter.js
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "path";
-import mkdirp from "mkdirp";
 
 const defaultPath = "./karma-ui5-reports";
 
@@ -52,7 +51,7 @@ export default function FileExportReporter(baseReporterDecorator, config, logger
 	baseReporterDecorator(this);
 
 	async function writeSingleFile(fileDir, fileName, content) {
-		await mkdirp(fileDir);
+		await fs.mkdir(fileDir, {recursive: true});
 		const uniqueFileName = await getUniqueFileName(fileDir, fileName);
 		const pathToWrite = path.join(fileDir, uniqueFileName);
 		if (!pathToWrite.startsWith(fileDir)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
 				"@ui5/server": "^3.0.0-rc.0",
 				"express": "^4.18.2",
 				"http-proxy": "^1.18.1",
-				"js-yaml": "^4.1.0",
-				"mkdirp": "^1.0.4"
+				"js-yaml": "^4.1.0"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.20.12",

--- a/package.json
+++ b/package.json
@@ -101,8 +101,7 @@
 		"@ui5/server": "^3.0.0-rc.0",
 		"express": "^4.18.2",
 		"http-proxy": "^1.18.1",
-		"js-yaml": "^4.1.0",
-		"mkdirp": "^1.0.4"
+		"js-yaml": "^4.1.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.20.12",

--- a/test/unit/fileExportReporter.js
+++ b/test/unit/fileExportReporter.js
@@ -7,16 +7,16 @@ import fs from "node:fs/promises";
 test.beforeEach(async (t) => {
 	const sinon = t.context.sinon = sinonGlobal.createSandbox();
 
-	t.context.mkdirpStub = sinon.stub().resolves();
+	t.context.mkdirStub = sinon.stub().resolves();
 	t.context.fsAccessStub = sinon.stub().callsFake(fs.access);
 	t.context.fsWriteFileStub = sinon.stub().callsFake(fs.writeFile);
 	t.context.pathJoinStub = sinon.stub().callsFake(path.join);
 
 	t.context.FileExportReporter = await esmock("../../lib/fileExportReporter.js", {
-		"mkdirp": t.context.mkdirpStub,
 		"node:fs/promises": {
 			access: t.context.fsAccessStub,
 			writeFile: t.context.fsWriteFileStub,
+			mkdir: t.context.mkdirStub
 		},
 		"node:path": {
 			join: t.context.pathJoinStub,
@@ -144,7 +144,7 @@ test("onBrowserComplete - tests crashed", async (t) => {
 });
 
 test("onBrowserComplete - save incoming export files", async (t) => {
-	const {FileExportReporter, base, logger, log, pathJoinStub, fsAccessStub, fsWriteFileStub, mkdirpStub} = t.context;
+	const {FileExportReporter, base, logger, log, pathJoinStub, fsAccessStub, fsWriteFileStub, mkdirStub} = t.context;
 
 	const browser = {};
 	const filePath1 = resolvedTestPath + "/filePath1";
@@ -178,8 +178,8 @@ test("onBrowserComplete - save incoming export files", async (t) => {
 	t.is(pathJoinStub.callCount, 5);
 	t.deepEqual(pathJoinStub.getCall(3).args, [resolvedTestPath, ".some.path.filename2"]); // test escapeFileName
 
-	t.is(mkdirpStub.callCount, 2);
-	t.deepEqual(mkdirpStub.getCall(0).args, [resolvedTestPath]);
+	t.is(mkdirStub.callCount, 2);
+	t.deepEqual(mkdirStub.getCall(0).args, [resolvedTestPath, {recursive: true}]);
 
 	t.is(fsWriteFileStub.callCount, 2);
 	t.deepEqual(fsWriteFileStub.getCall(0).args, [filePath1, "content1"]);


### PR DESCRIPTION
The recursive option is available since Node v10.12, which makes the
use of thirdparty packages obsolete for most use cases.
