### PR TITLE
[BREAKING] Require Node.js ^16.18.0 || >=18.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"karma-plugin"
 	],
 	"engines": {
-		"node": "^16.18.0 || >=18.0.0",
+		"node": "^16.18.0 || >=18.12.0",
 		"npm": ">= 8"
 	},
 	"repository": {


### PR DESCRIPTION
Follow-up of https://github.com/SAP/karma-ui5/pull/507 with alignments
based on latest changes of UI5 Tooling v3 Node.js requirements.

BREAKING CHANGE:
Raising the minimum required Node v18 version to 18.12.0.
