### PR TITLE
[INTERNAL] Remove unused typescript devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
 				"qunit": "^2.19.4",
 				"rimraf": "^4.4.1",
 				"sinon": "^15.0.3",
-				"typescript": "^4.9.5",
 				"webpack": "^5.79.0",
 				"webpack-cli": "^5.0.1"
 			},
@@ -15264,19 +15263,6 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
-		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
-			}
-		},
 		"node_modules/ua-parser-js": {
 			"version": "0.7.35",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
@@ -27769,12 +27755,6 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
-		},
-		"typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.35",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
 		"postversion": "git push --follow-tags",
 		"release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version",
-		"depcheck": "depcheck --ignores core-js,typescript,webpack-cli"
+		"depcheck": "depcheck --ignores core-js,webpack-cli"
 	},
 	"nyc": {
 		"reporter": [
@@ -131,7 +131,6 @@
 		"qunit": "^2.19.4",
 		"rimraf": "^4.4.1",
 		"sinon": "^15.0.3",
-		"typescript": "^4.9.5",
 		"webpack": "^5.79.0",
 		"webpack-cli": "^5.0.1"
 	}


### PR DESCRIPTION
Introduced via c0164c7aef4d6c40255004d4fc5d4a817b973f63 to meet the
peerDependency of eslint-plugin-jest.

Jest has been removed in favor f ava via
https://github.com/SAP/karma-ui5/pull/511 so it is not needed anymore.
