### PR TITLE
[FIX] Ensure defined urlParameters order

### DIFF
--- a/lib/client/browser.cjs
+++ b/lib/client/browser.cjs
@@ -169,8 +169,6 @@ function getTestPageName(qunitHtmlFile) {
 			config.urlParameters.forEach(function(urlParameter) {
 				url.searchParams.append(urlParameter.key, urlParameter.value);
 			});
-			// Sort params for consistency between browsers (probably caused by polyfill)
-			url.searchParams.sort();
 
 			return url.toString();
 		}

--- a/test/integration/application-ui5-tooling-url-parameters/webapp/test/test.qunit.js
+++ b/test/integration/application-ui5-tooling-url-parameters/webapp/test/test.qunit.js
@@ -6,7 +6,8 @@ sap.ui.getCore().attachInit(function() {
 	"use strict";
 
 	QUnit.test("URL Parameters", function(assert) {
-		assert.strictEqual(document.location.search, encodeURI("?0=0️⃣&0=&hidepassed=true"),
+		assert.strictEqual(document.location.search,
+			encodeURI("?paramFromTestSuite=should-be-first&hidepassed=true&0=0️⃣&0="),
 			"Configured URL parameters got applied");
 		assert.ok(QUnit.config.hidepassed, "URL parameter configured QUnit");
 	});

--- a/test/integration/application-ui5-tooling-url-parameters/webapp/test/testsuite.qunit.js
+++ b/test/integration/application-ui5-tooling-url-parameters/webapp/test/testsuite.qunit.js
@@ -4,7 +4,7 @@ window.suite = function() {
 	// eslint-disable-next-line new-cap
 	const oSuite = new parent.jsUnitTestSuite();
 	const sContextPath = location.pathname.substring(0, location.pathname.lastIndexOf("/") + 1);
-	oSuite.addTestPage(sContextPath + "test.qunit.html");
+	oSuite.addTestPage(sContextPath + "test.qunit.html?paramFromTestSuite=should-be-first");
 
 	return oSuite;
 };

--- a/test/integration/integration.js
+++ b/test/integration/integration.js
@@ -110,7 +110,6 @@ test.after(() => {
 });
 
 const configPaths = glob.sync(["./*/karma*.conf.js"], {cwd: __dirname});
-// const configPaths = ["application-ui5-tooling/karma-ui5-config-not-found.conf.js"];
 for (const configPath of configPaths) {
 	registerIntegrationTest(configPath);
 }


### PR DESCRIPTION
Some testsuites may define url parameters for a test and expect the
order of parameters to be unchanged.

It is not fully clear for which cases the sorting has been implemented
initially but it has been decided to rather check for those issues
instead of always sort to have the same order in every browser.

BCP: 2370044253
