### PR TITLE
[INTERNAL] Fix coverage setup in newer Node versions

### DIFF
--- a/ava.config.js
+++ b/ava.config.js
@@ -3,5 +3,6 @@ export default {
 	nodeArguments: [
 		"--loader=esmock",
 		"--no-warnings"
-	]
+	],
+	workerThreads: false
 };


### PR DESCRIPTION
Recent changes in Node 20 have also been down-ported to 18.19.0.
See: https://github.com/SAP/ui5-server/pull/602
