### PR TITLE
[BREAKING] Drop node v16, v18, v21

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     - uses: actions/checkout@v4.1.7
 
-    - name: Use Node.js LTS 18.x
+    - name: Use Node.js v20.11.0
       uses: actions/setup-node@v4.0.3
       with:
-        node-version: 18.x
+        node-version: 20.11.0
 
     - name: Install dependencies
       run: npm ci
@@ -36,11 +36,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18]
+        node-version: [20, 22]
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        include:
-          - node-version: 19
-            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -81,10 +78,10 @@ jobs:
 
     - uses: actions/checkout@v4.1.7
 
-    - name: Use Node.js LTS 18.x
+    - name: Use Node.js LTS 20.x
       uses: actions/setup-node@v4.0.3
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/saucelabs.yml
+++ b/.github/workflows/saucelabs.yml
@@ -18,12 +18,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4.1.7
-    - name: Use Node.js LTS 16.x
+    - name: Use Node.js LTS 20.x
       uses: actions/setup-node@v4.0.3
       with:
-        # There are issues with some tests, related to Node 18 and SauceLabs
-        # It seems that files from the local UI5 server can't be loaded due to CSP
-        node-version: 16.x
+        node-version: 20.x
     - run: npm ci
     - name: Install @openui5/sap.ui.core@1.71.x
       run: npm install -D @openui5/sap.ui.core@1.71.x

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"karma-plugin"
 	],
 	"engines": {
-		"node": "^16.18.0 || >=18.12.0",
+		"node": "^20.11.0 || >=22.0.0",
 		"npm": ">= 8"
 	},
 	"repository": {


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js and npm releases has been dropped.
Only Node.js 20.11.x and >=22.0.0 as well as npm v8 or higher are supported.

JIRA: CPOUI5FOUNDATION-846
