### PR TITLE
Add middleware to support Maven-managed dependencies on Fiori Pipeline

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -564,7 +564,7 @@ export default class Framework {
 		}
 		const oReqUrl = parseUrl(req.url);
 		const sPath = oReqUrl.pathname;
-		//This executes after beforeMiddlewareRewriteUrl, so paths have been remapped from /base/resources to /resources
+		// This executes after beforeMiddlewareRewriteUrl, so paths have been remapped from /base/resources to /resources
 		if (sPath.startsWith("/resources")) {
 			const sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/resources".length));
 			if (existsSync(sSearchPath)) {

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -564,8 +564,6 @@ export default class Framework {
 		}
 		const oReqUrl = parseUrl(req.url);
 		const sPath = oReqUrl.pathname;
-		// This executes after beforeMiddlewareRewriteUrl, so paths have been remapped
-		// from /base/resources to /resources
 		if (sPath.startsWith("/base/resources")) {
 			const sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/base/resources".length));
 			if (existsSync(sSearchPath)) {

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -553,21 +553,21 @@ export default class Framework {
 	 *
 	 * @param {http.ClientRequest} req Client request object
 	 * @param {http.ServerResponse} res Server response object
-	 * @param {function} next Next middleware
-	 * @returns
+	 * @param {Function} next Next middleware
+	 * @returns {void}
 	 */
-	middlewareMavenDependencies(req, res, next){
+	middlewareMavenDependencies(req, res, next) {
 		const sMvnDependencyDir = path.resolve("./target/dependency/META-INF/resources");
-		if (req.method !== "GET" || !existsSync(sMvnDependencyDir)){
+		if (req.method !== "GET" || !existsSync(sMvnDependencyDir)) {
 			next();
 			return;
 		}
 		const oReqUrl = parseUrl(req.url);
 		const sPath = oReqUrl.pathname;
 		//This executes after beforeMiddlewareRewriteUrl, so paths have been remapped from /base/resources to /resources
-		if (sPath.startsWith("/resources")){
-			let sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/resources".length));
-			if (existsSync(sSearchPath)){
+		if (sPath.startsWith("/resources")) {
+			const sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/resources".length));
+			if (existsSync(sSearchPath)) {
 				const oBody = readFileSync(sSearchPath);
 				res.write(oBody);
 				res.statusCode = 200;

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -2,13 +2,12 @@ import {parse as parseUrl} from "node:url";
 import http from "node:http";
 import https from "node:https";
 import httpProxy from "http-proxy";
-import {statSync, readFileSync} from "node:fs";
+import {statSync, readFileSync, existsSync} from "node:fs";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 import yaml from "js-yaml";
 import {Router} from "express";
 import {ErrorMessage} from "./errors.js";
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default class Framework {
@@ -547,7 +546,37 @@ export default class Framework {
 		req.url = this.rewriteUrl(req.url);
 		next();
 	}
-
+	/**
+	 * For Maven-managed UI5 libraries (fiori pipeline), dependencies are extracted to the
+	 * target/dependency/META-INF/resources directory inside the project.  This middleware
+	 * returns the file contents if found inside the dependency directory.
+	 *
+	 * @param {http.ClientRequest} req Client request object
+	 * @param {http.ServerResponse} res Server response object
+	 * @param {function} next Next middleware
+	 * @returns
+	 */
+	middlewareMavenDependencies(req, res, next){
+		const sMvnDependencyDir = path.resolve("./target/dependency/META-INF/resources");
+		if (req.method !== "GET" || !existsSync(sMvnDependencyDir)){
+			next();
+			return;
+		}
+		const oReqUrl = parseUrl(req.url);
+		const sPath = oReqUrl.pathname;
+		//This executes after beforeMiddlewareRewriteUrl, so paths have been remapped from /base/resources to /resources
+		if (sPath.startsWith("/resources")){
+			let sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/resources".length));
+			if (existsSync(sSearchPath)){
+				const oBody = readFileSync(sSearchPath);
+				res.write(oBody);
+				res.statusCode = 200;
+				res.end();
+				return;
+			}
+		}
+		next();
+	}
 	async setupMiddleware() {
 		const config = this.config;
 
@@ -569,6 +598,7 @@ export default class Framework {
 
 		if (middleware) {
 			config.ui5._middleware = new Router();
+			config.ui5._middleware.use(this.middlewareMavenDependencies.bind(this));
 			config.ui5._middleware.use(this.middlewareRewriteUrl.bind(this));
 			config.ui5._middleware.use(middleware);
 			config.middleware.push("ui5--middleware");

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -566,6 +566,16 @@ export default class Framework {
 		const sPath = oReqUrl.pathname;
 		// This executes after beforeMiddlewareRewriteUrl, so paths have been remapped
 		// from /base/resources to /resources
+		if (sPath.startsWith("/base/resources")) {
+			const sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/base/resources".length));
+			if (existsSync(sSearchPath)) {
+				const oBody = readFileSync(sSearchPath);
+				res.write(oBody);
+				res.statusCode = 200;
+				res.end();
+				return;
+			}
+		}
 		if (sPath.startsWith("/resources")) {
 			const sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/resources".length));
 			if (existsSync(sSearchPath)) {
@@ -583,6 +593,7 @@ export default class Framework {
 
 		if (config.ui5.type === "library") {
 			config.ui5._beforeMiddleware = new Router();
+			config.ui5._beforeMiddleware.use(this.middlewareMavenDependencies.bind(this));
 			config.ui5._beforeMiddleware.use(this.beforeMiddlewareRewriteUrl.bind(this));
 			config.beforeMiddleware.push("ui5--beforeMiddleware");
 		}
@@ -599,7 +610,6 @@ export default class Framework {
 
 		if (middleware) {
 			config.ui5._middleware = new Router();
-			config.ui5._middleware.use(this.middlewareMavenDependencies.bind(this));
 			config.ui5._middleware.use(this.middlewareRewriteUrl.bind(this));
 			config.ui5._middleware.use(middleware);
 			config.middleware.push("ui5--middleware");

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -564,7 +564,8 @@ export default class Framework {
 		}
 		const oReqUrl = parseUrl(req.url);
 		const sPath = oReqUrl.pathname;
-		// This executes after beforeMiddlewareRewriteUrl, so paths have been remapped from /base/resources to /resources
+		// This executes after beforeMiddlewareRewriteUrl, so paths have been remapped
+		// from /base/resources to /resources
 		if (sPath.startsWith("/resources")) {
 			const sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/resources".length));
 			if (existsSync(sSearchPath)) {

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -576,16 +576,6 @@ export default class Framework {
 				return;
 			}
 		}
-		if (sPath.startsWith("/resources")) {
-			const sSearchPath = path.resolve(sMvnDependencyDir + sPath.substring("/resources".length));
-			if (existsSync(sSearchPath)) {
-				const oBody = readFileSync(sSearchPath);
-				res.write(oBody);
-				res.statusCode = 200;
-				res.end();
-				return;
-			}
-		}
 		next();
 	}
 	async setupMiddleware() {


### PR DESCRIPTION
This change adds a middleware definition to support libraries with dependencies during builds on the Fiori Pipeline.  

Currently the pipeline copies dependencies into the project's src directory to run test automation.  This causes the framework to fail to initialize because of conflicting manifest.json files.

Since the files are already consolidated into the Maven target directory at target/dependency/META-INF/resources, using a middleware to retrieve dependency files from there instead of placing them in the src directory resolves the build failure.